### PR TITLE
fixed initilization order

### DIFF
--- a/src/BLEAutoScan.cpp
+++ b/src/BLEAutoScan.cpp
@@ -18,7 +18,9 @@ BLEAutoScan::BLEAutoScan(BLEControllerRegistry& controllerRegistry,
       _userCallbackQueue(userCallbackQueue) {
   xTaskCreate(_autoScanTaskFn, "_autoScanTaskFn", 10000, this, 0, &_autoScanTask);
   configASSERT(_autoScanTask);
+}
 
+void BLEAutoScan::init() {
   auto* pScan = NimBLEDevice::getScan();
   pScan->setScanCallbacks(&_scanCallbacksImpl, false);
   pScan->setMaxResults(0);

--- a/src/BLEAutoScan.h
+++ b/src/BLEAutoScan.h
@@ -10,6 +10,7 @@ class BLEAutoScan {
               QueueHandle_t& userCallbackQueue);
   ~BLEAutoScan();
 
+  void init();
   void enable();
   void disable();
   bool isEnabled() const;

--- a/src/BLEGamepadClient.cpp
+++ b/src/BLEGamepadClient.cpp
@@ -8,6 +8,7 @@
 #include "config.h"
 
 bool BLEGamepadClient::_initialized = false;
+bool BLEGamepadClient::_autoScanInitialized = false;
 TaskHandle_t BLEGamepadClient::_autoScanTask;
 QueueHandle_t BLEGamepadClient::_userCallbackQueue;
 BLEControllerRegistry BLEGamepadClient::_controllerRegistry(_autoScanTask, _userCallbackQueue);
@@ -24,7 +25,9 @@ BLEUserCallbackRunner BLEGamepadClient::_userCallbackRunner(_autoScan, _userCall
 void BLEGamepadClient::init(const bool deleteBonds) {
   _initSelf();
 
-  if (!NimBLEDevice::isInitialized()) {
+  const bool nimbleWasAlreadyInitialized = NimBLEDevice::isInitialized();
+
+  if (!nimbleWasAlreadyInitialized) {
     BLEGC_LOGD("Initializing NimBLE");
     NimBLEDevice::init(CONFIG_BT_BLEGC_DEVICE_NAME);
     NimBLEDevice::setPower(CONFIG_BT_BLEGC_POWER_DBM);
@@ -34,6 +37,11 @@ void BLEGamepadClient::init(const bool deleteBonds) {
     if (deleteBonds) {
       NimBLEDevice::deleteAllBonds();
     }
+  }
+
+  if (!_autoScanInitialized) {
+    _autoScan.init();
+    _autoScanInitialized = true;
   }
 }
 

--- a/src/BLEGamepadClient.h
+++ b/src/BLEGamepadClient.h
@@ -21,6 +21,7 @@ class BLEGamepadClient {
  private:
   static void _initSelf();
   static bool _initialized;
+  static bool _autoScanInitialized;
   static TaskHandle_t _autoScanTask;
   static QueueHandle_t _userCallbackQueue;
   static BLEAutoScan _autoScan;


### PR DESCRIPTION
# Fix crash on boot caused by premature NimBLE access in static initializer

## Problem

Calling `controller.begin()` caused an immediate ESP32 crash with:

```
assert failed: npl_freertos_mutex_pend ... npl_os_freertos.c (mu->handle ...)
```

followed by a `SW_CPU_RESET` boot loop.

## Root cause

`BLEGamepadClient` holds its subsystems (`_controllerRegistry`, `_autoScan`, `_userCallbackRunner`) as **static member variables**. In C++, static members of a translation unit are initialized before `main()` / `setup()` is called — which on ESP32/Arduino means before `NimBLEDevice::init()` has ever been called.

The `BLEAutoScan` constructor was calling `NimBLEDevice::getScan()` directly:

```cpp
// BLEAutoScan constructor (before fix)
auto* pScan = NimBLEDevice::getScan();
pScan->setScanCallbacks(&_scanCallbacksImpl, false);
pScan->setMaxResults(0);
```

`getScan()` internally acquires a NimBLE-managed FreeRTOS mutex that does not exist yet at this point in the boot sequence, triggering the assertion failure. The crash happened before any controller communication or BLE scan started — the Xbox controller was irrelevant.

## Fix

Moved the three NimBLE-dependent lines out of the `BLEAutoScan` constructor into a new `BLEAutoScan::init()` method. This method is called from `BLEGamepadClient::init()` immediately after `NimBLEDevice::init()` completes, when it is safe to access the BLE stack.

## Changes

- `src/BLEAutoScan.h` — declared `void init()`
- `src/BLEAutoScan.cpp` — moved `NimBLEDevice::getScan()` setup from constructor into `init()`
- `src/BLEGamepadClient.h` — added `static bool _autoScanInitialized`
- `src/BLEGamepadClient.cpp` — added `_autoScanInitialized` flag; calls `_autoScan.init()` in `BLEGamepadClient::init()` after NimBLE is ready, guarded so it only runs once (safe if `NimBLEDevice::init()` was called manually by the user beforehand)

## Verified

Flashed `Xbox_ReadingControls` example to an ESP32-D0WD-V3. Before the fix: immediate crash on boot. After the fix: clean boot, serial prints `controller not connected` while scanning, no reset.
